### PR TITLE
优化 Unix Java 搜索行为

### DIFF
--- a/PCL2.Neo/Controls/MyRadioButton.axaml
+++ b/PCL2.Neo/Controls/MyRadioButton.axaml
@@ -51,40 +51,40 @@
                 <BrushTransition Duration="0:0:0.1" Property="Background" />
             </Transitions>
         </Setter>
-        
+
         <Style Selector="^:white">
-            <Setter Property="Foreground" Value="#FFFFFF" />
+            <Setter Property="Foreground" Value="{DynamicResource ColorBrushWhite}" />
             <Setter Property="Background" Value="{DynamicResource ColorBrushSemiTransparent}" />
             <Style Selector="^:pointerover">
-                <Setter Property="Foreground" Value="#FFFFFF" />
+                <Setter Property="Foreground" Value="{DynamicResource ColorBrushWhite}" />
                 <Setter Property="Background" Value="#32eaf2fe" />
             </Style>
-            
+
             <Style Selector="^:pressed">
                 <Setter Property="Background" Value="#78EAF2FE" />
             </Style>
-            
+
             <Style Selector="^:checked">
                 <Setter Property="Foreground" Value="{DynamicResource ColorBrush3}" />
-                <Setter Property="Background" Value="#FFFFFF" />
+                <Setter Property="Background" Value="{DynamicResource ColorBrushWhite}" />
             </Style>
         </Style>
-        
+
         <Style Selector="^:highlight">
             <Setter Property="Foreground" Value="{DynamicResource ColorBrush3}" />
             <Setter Property="Background" Value="{DynamicResource ColorBrushSemiTransparent}" />
-            
+
             <Style Selector="^:pointerover">
                 <Setter Property="Foreground" Value="{DynamicResource ColorBrush3}" />
                 <Setter Property="Background" Value="{DynamicResource ColorBrush7}" />
             </Style>
-            
+
             <Style Selector="^:pressed">
                 <Setter Property="Background" Value="{DynamicResource ColorBrush6}" />
             </Style>
-            
+
             <Style Selector="^:checked">
-                <Setter Property="Foreground" Value="#FFFFFF" />
+                <Setter Property="Foreground" Value="{DynamicResource ColorBrushWhite}" />
                 <Setter Property="Background" Value="{DynamicResource ColorBrush3}" />
             </Style>
         </Style>

--- a/PCL2.Neo/Models/Minecraft/Java/Java.cs
+++ b/PCL2.Neo/Models/Minecraft/Java/Java.cs
@@ -8,7 +8,7 @@ namespace PCL2.Neo.Models.Minecraft.Java
     /// <summary>
     /// 测试
     /// </summary>
-    public class Java
+    public static class Java
     {
         public static async Task<IEnumerable<JavaEntity>> SearchJava()
         {
@@ -34,21 +34,11 @@ namespace PCL2.Neo.Models.Minecraft.Java
             // this problenm is fixed by follow code
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                return await Windows.SearchJavaAsync(); // TODO: Read setting to get whether full search or not.
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                return await Unix.SearchJava();
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                return await Unix.SearchJava();
-            }
-            else
-            {
-                throw new PlatformNotSupportedException();
-            }
+                return await Windows.SearchJavaAsync();
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                return await Unix.SearchJavaAsync();
+
+            throw new PlatformNotSupportedException();
         }
     }
 }

--- a/PCL2.Neo/Models/Minecraft/Java/JavaData.cs
+++ b/PCL2.Neo/Models/Minecraft/Java/JavaData.cs
@@ -1,21 +1,22 @@
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 
 namespace PCL2.Neo.Models.Minecraft.Java
 {
     public class JavaEntity(string path)
     {
-        public string Path = path;
+        public readonly string Path = path;
 
-        public bool IsUseable = true;
+        public bool IsUsable = true;
 
         private void JavaInfoInit()
         {
             // set version
-            var regexMatch = Regex.Match(Output, """version "([\d._]+)""");
+            var regexMatch = Regex.Match(Output, """version\s+"([\d._]+)""");
             var match = Regex.Match(regexMatch.Success ? regexMatch.Groups[1].Value : string.Empty,
-                @"^(\d+)\.");
+                @"^(\d+)");
             _version = match.Success ? int.Parse(match.Groups[1].Value) : 0;
 
             if (_version == 1)
@@ -51,8 +52,10 @@ namespace PCL2.Neo.Models.Minecraft.Java
             }
         }
 
-        public string JavaExe => System.IO.Path.Combine(Path, "java.exe");
-        public string JavaWExe => System.IO.Path.Combine(Path, "javaw.exe");
+        public string JavaExe => System.IO.Path.Combine(Path, "java");
+
+        public string? JavaWExe
+            => RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? System.IO.Path.Combine(Path, "javaw.exe") : null;
 
         private string? _output;
 
@@ -81,7 +84,8 @@ namespace PCL2.Neo.Models.Minecraft.Java
                     return _isJre.Value;
                 }
 
-                var result = File.Exists(Path + "\\javac.exe");
+                var result = File.Exists(System.IO.Path.Combine(Path,
+                    RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "javac.exe" : "javac"));
                 _isJre = result;
                 return result;
             }

--- a/PCL2.Neo/Models/Minecraft/Java/Windows.cs
+++ b/PCL2.Neo/Models/Minecraft/Java/Windows.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace PCL2.Neo.Models.Minecraft.Java
 {
-    public class Windows
+    public static class Windows
     {
         private const int MaxDeep = 7;
 


### PR DESCRIPTION
- 在`Unix.cs`中，将`SearchJavaExecutables`返回的路径改为包含java的目录以匹配Windows的行为；
- 修改文件位置以匹配命名空间；
- 更改版本号正则表达式匹配规则；
- 去除`JavaExe`中的`.exe`后缀