### PR TITLE
优化 Java 搜索行为，主要针对 Unix

### DIFF
--- a/PCL2.Neo/Models/Minecraft/Java/Java.cs
+++ b/PCL2.Neo/Models/Minecraft/Java/Java.cs
@@ -8,7 +8,7 @@ namespace PCL2.Neo.Models.Minecraft.Java
     /// <summary>
     /// 测试
     /// </summary>
-    public class Java
+    public static class Java
     {
         public static async Task<IEnumerable<JavaEntity>> SearchJava()
         {
@@ -34,21 +34,11 @@ namespace PCL2.Neo.Models.Minecraft.Java
             // this problenm is fixed by follow code
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                return await Windows.SearchJavaAsync(); // TODO: Read setting to get whether full search or not.
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                return await Unix.SearchJava();
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                return await Unix.SearchJava();
-            }
-            else
-            {
-                throw new PlatformNotSupportedException();
-            }
+                return await Windows.SearchJavaAsync();
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                return await Unix.SearchJavaAsync();
+
+            throw new PlatformNotSupportedException();
         }
     }
 }

--- a/PCL2.Neo/Models/Minecraft/Java/Java.cs
+++ b/PCL2.Neo/Models/Minecraft/Java/Java.cs
@@ -35,8 +35,10 @@ namespace PCL2.Neo.Models.Minecraft.Java
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 return await Windows.SearchJavaAsync();
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                return await Unix.SearchJavaAsync();
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                return await Unix.SearchJavaAsync(OSPlatform.Linux);
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                return await Unix.SearchJavaAsync(OSPlatform.OSX);
 
             throw new PlatformNotSupportedException();
         }

--- a/PCL2.Neo/Models/Minecraft/Java/JavaData.cs
+++ b/PCL2.Neo/Models/Minecraft/Java/JavaData.cs
@@ -1,21 +1,22 @@
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 
 namespace PCL2.Neo.Models.Minecraft.Java
 {
     public class JavaEntity(string path)
     {
-        public string Path = path;
+        public readonly string Path = path;
 
-        public bool IsUseable = true;
+        public bool IsUsable = true;
 
         private void JavaInfoInit()
         {
             // set version
-            var regexMatch = Regex.Match(Output, """version "([\d._]+)""");
+            var regexMatch = Regex.Match(Output, """version\s+"([\d._]+)""");
             var match = Regex.Match(regexMatch.Success ? regexMatch.Groups[1].Value : string.Empty,
-                @"^(\d+)\.");
+                @"^(\d+)");
             _version = match.Success ? int.Parse(match.Groups[1].Value) : 0;
 
             if (_version == 1)
@@ -51,8 +52,10 @@ namespace PCL2.Neo.Models.Minecraft.Java
             }
         }
 
-        public string JavaExe => System.IO.Path.Combine(Path, "java.exe");
-        public string JavaWExe => System.IO.Path.Combine(Path, "javaw.exe");
+        public string JavaExe => System.IO.Path.Combine(Path, "java");
+
+        public string? JavaWExe
+            => RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? System.IO.Path.Combine(Path, "javaw.exe") : null;
 
         private string? _output;
 
@@ -81,7 +84,8 @@ namespace PCL2.Neo.Models.Minecraft.Java
                     return _isJre.Value;
                 }
 
-                var result = File.Exists(Path + "\\javac.exe");
+                var result = File.Exists(System.IO.Path.Combine(Path,
+                    RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "javac.exe" : "javac"));
                 _isJre = result;
                 return result;
             }

--- a/PCL2.Neo/Models/Minecraft/Java/JavaData.cs
+++ b/PCL2.Neo/Models/Minecraft/Java/JavaData.cs
@@ -84,10 +84,10 @@ namespace PCL2.Neo.Models.Minecraft.Java
                     return _isJre.Value;
                 }
 
-                var result = File.Exists(System.IO.Path.Combine(Path,
+                var hasJavac = File.Exists(System.IO.Path.Combine(Path,
                     RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "javac.exe" : "javac"));
-                _isJre = result;
-                return result;
+                _isJre = !hasJavac;
+                return _isJre.Value;
             }
         }
 

--- a/PCL2.Neo/Models/Minecraft/Java/Unix.cs
+++ b/PCL2.Neo/Models/Minecraft/Java/Unix.cs
@@ -1,126 +1,156 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace PCL2.Neo.Models.Minecraft.Java
 {
     /// <summary>
-    /// 处理Unix系统下的java
+    /// 处理Unix系统下的java搜索
+    /// 需要重新梳理一下逻辑：
+    /// 1. 得到所有可能的 Java 目录 2. 检查其中是否有 Java 可执行文件 3. 归类返回，返回的是应是目录而非文件位置
     /// </summary>
     internal static class Unix
     {
-#warning "该方法未经过测试，可能无法正常工作 Unix/SearchJavaAsync"
-        public static async Task<IEnumerable<JavaEntity>> SearchJavaAsync() =>
-            await Task.Run(() => FindJavaExecutablePath().Select(it => new JavaEntity(it)));
-
-        private static IEnumerable<string> FindJavaExecutablePath() =>
-            GetPotentialJavaDir()
-                .Where(Directory.Exists)
-                .SelectMany(SearchJavaExecutables)
-                .Select(Path.GetDirectoryName)
-                .Distinct()!;
-
-        private static bool IsValidJavaExecutable(string filePath)
+        public static async Task<IEnumerable<JavaEntity>> SearchJavaAsync(OSPlatform platform)
         {
-            // TODO: check execute permission
-            return File.Exists(filePath);
+            var javaPaths = new HashSet<string>();
+            javaPaths.UnionWith(GetOsKnowDirs(platform));
+            if (CheckJavaHome() is { } javaHome) javaPaths.Add(javaHome);
+            if (CheckWithWhichJava() is { } whichJava) javaPaths.Add(whichJava);
+            if(platform == OSPlatform.OSX) javaPaths.UnionWith(GetJavaHomesFromLibexec());
+            var validPaths = new HashSet<string>();
+            foreach (string path in javaPaths.Where(Directory.Exists))
+            {
+                var foundPaths = await SearchJavaExecutablesAsync(path);
+                foreach (string foundPath in foundPaths)
+                {
+                    var directoryName = Path.GetDirectoryName(foundPath);
+                    if (directoryName != null) validPaths.Add(directoryName);
+                }
+            }
+            return validPaths.Select(x => new JavaEntity(x));
         }
 
-        private static IEnumerable<string> SearchJavaExecutables(string basePath)
+        private static List<string> GetOsKnowDirs(OSPlatform platform)
         {
-            try
-            {
-                return Directory
-                    .EnumerateFiles(basePath, "java",
-                        new EnumerationOptions
-                        {
-                            RecurseSubdirectories = true, MaxRecursionDepth = 7, IgnoreInaccessible = true
-                        })
-                    .Where(IsValidJavaExecutable);
-            }
-            catch (Exception)
-            {
-                // TODO: Logger handling exceptions
-            }
-
-            return [];
-        }
-
-        private static IEnumerable<string> GetPotentialJavaDir()
-        {
-            var paths = new List<string>();
             var homeDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-
-            // add path
-            paths.AddRange(Environment.GetEnvironmentVariable("PATH")?.Split(':') ?? []);
-
-            // add system paths
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                paths.AddRange([
-                    "/usr/lib/jvm",
-                    "/usr/java",
-                    "/opt/java",
-                    "/opt/jdk",
-                    "/opt/jre",
-                    "/usr/local/java",
-                    "/usr/local/jdk",
-                    "/usr/local/jre"
-                ]);
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                paths.AddRange([
+            var knowDirs = new List<string>();
+            knowDirs.AddRange([
+                "/usr/lib/jvm",
+                "/usr/java",
+                "/opt/java",
+                "/opt/jdk",
+                "/opt/jre",
+                "/usr/local/java",
+                "/usr/local/jdk",
+                "/usr/local/jre",
+                "/usr/local/opt",
+                Path.Combine(homeDir, ".sdkman/candidates/java"),
+            ]);
+            if (platform == OSPlatform.OSX)
+                knowDirs.AddRange([
                     "/Library/Java/JavaVirtualMachines",
                     $"{homeDir}/Library/Java/JavaVirtualMachines",
                     "/System/Library/Frameworks/JavaVM.framework/Versions", // Older macOS Java installs
-                    "/usr/local/opt", // Homebrew links (e.g., /usr/local/opt/openjdk)
-                    "/opt/homebrew/opt", // Homebrew on Apple Silicon
-                    "/opt/java", // Manual installs sometimes go here too
-                    "/opt/jdk",
-                    "/opt/jre"
+                    "/opt/homebrew/opt/java", // Homebrew on Apple Silicon
                 ]);
-            }
-            else
-            {
-                // platform not supported
-                throw new PlatformNotSupportedException();
-            }
+            return knowDirs.ConvertAll(Path.GetFullPath);
+        }
 
-            // add home dirs
-
-            if (!string.IsNullOrEmpty(homeDir))
-            {
-                paths.AddRange([
-                    Path.Combine(homeDir, ".jdks"), // Common for SDKMAN
-                    Path.Combine(homeDir, "java"),
-                    Path.Combine(homeDir, ".java"), // Less common, but possible
-                    Path.Combine(homeDir, "sdks", "java"), // IntelliJ default download location?),
-                ]);
-            }
-
-            // add java home path
+        private static string? CheckJavaHome()
+        {
             var javaHome = Environment.GetEnvironmentVariable("JAVA_HOME");
-            if (string.IsNullOrEmpty(javaHome) || !Directory.Exists(javaHome))
+            return string.IsNullOrEmpty(javaHome) ? null : javaHome;
+        }
+
+        private static string? CheckWithWhichJava()
+        {
+            var whichJava = RunCommand("which", "java");
+            if (!File.Exists(whichJava))
+                return null;
+            var resolvedPath = Path.GetFullPath(whichJava);
+            return Path.GetDirectoryName(resolvedPath);
+        }
+
+
+        static HashSet<string> GetJavaHomesFromLibexec()
+        {
+            var result = new HashSet<string>();
+            var output = RunCommand("/usr/libexec/java_home", "-V");
+
+            var regex = new Regex(@"(?<path>/Library/Java/JavaVirtualMachines/.*?/Contents/Home)");
+            foreach (Match match in regex.Matches(output))
             {
-                return paths.Distinct();
+                var homePath = match.Groups["path"].Value;
+                var javaBin = Path.Combine(homePath, "bin", "java");
+                if (File.Exists(javaBin))
+                    result.Add(Path.GetDirectoryName(javaBin)!);
             }
 
-            paths.Add(javaHome);
-            // add java home parent path
-            var parent =
-                Path.GetDirectoryName(javaHome.TrimEnd(Path.DirectorySeparatorChar,
-                    Path.AltDirectorySeparatorChar));
-            if (!string.IsNullOrEmpty(parent) && Directory.Exists(parent) && !paths.Contains(parent))
+            return result;
+        }
+
+        static string RunCommand(string command, string args)
+        {
+            try
             {
-                paths.Add(parent);
+                var psi = new ProcessStartInfo
+                {
+                    FileName = command,
+                    Arguments = args,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                };
+                using var process = Process.Start(psi);
+                var output = process!.StandardOutput.ReadToEnd();
+                output += process.StandardError.ReadToEnd();
+                process.WaitForExit();
+                return output.Trim();
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
+
+        private static Task<IEnumerable<string>> SearchJavaExecutablesAsync(string basePath)
+        {
+            var javaExecutables = new List<string>();
+            try
+            {
+                var options = new EnumerationOptions
+                {
+                    RecurseSubdirectories = true, MaxRecursionDepth = 7, IgnoreInaccessible = true
+                };
+
+                var files = Directory.EnumerateFiles(basePath, "java", options);
+                foreach (var file in files)
+                {
+                    if (IsValidJavaExecutableAsync(file))
+                    {
+                        javaExecutables.Add(file);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                // TODO: Logger handling exceptions
+                Console.WriteLine(ex);
             }
 
-            return paths.Distinct();
+            return Task.FromResult<IEnumerable<string>>(javaExecutables);
+        }
+
+        private static bool IsValidJavaExecutableAsync(string filePath)
+        {
+            return File.Exists(filePath);
         }
     }
 }

--- a/PCL2.Neo/Models/Minecraft/Java/Windows.cs
+++ b/PCL2.Neo/Models/Minecraft/Java/Windows.cs
@@ -26,9 +26,9 @@ namespace PCL2.Neo.Models.Minecraft.Java
             var javaEntities = new List<string>();
 
             javaEntities.AddRange(SearchRegister()); // search registies
-            javaEntities.AddRange(SearchEnvionment()); // search path
+            javaEntities.AddRange(SearchEnvironment()); // search path
 
-            if (fullSearch) javaEntities.AddRange(await SearchDirves(maxDeep)); // full search mode
+            if (fullSearch) javaEntities.AddRange(await SearchDrives(maxDeep)); // full search mode
 
             var result = TargetSearchFolders
                 .Where(Path.Exists)
@@ -62,7 +62,7 @@ namespace PCL2.Neo.Models.Minecraft.Java
             return javaList;
         }
 
-        private static IEnumerable<string> SearchEnvionment()
+        private static IEnumerable<string> SearchEnvironment()
         {
             var javaList = new List<string>();
 
@@ -119,7 +119,7 @@ namespace PCL2.Neo.Models.Minecraft.Java
             string folderPath, int deep = 0, int maxDeep = MaxDeep)
             => Task.Run((() => SearchFolders(folderPath, deep, maxDeep)));
 
-        private static Task<IEnumerable<string>> SearchDirves(int maxDeep)
+        private static Task<IEnumerable<string>> SearchDrives(int maxDeep)
         {
             var readyDrive = DriveInfo.GetDrives()
                 .Where(d => d is { IsReady: true, DriveType: DriveType.Fixed })

--- a/PCL2.Neo/Models/Minecraft/Java/Windows.cs
+++ b/PCL2.Neo/Models/Minecraft/Java/Windows.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
 #pragma warning disable CA1416 // Platform compatibility
@@ -25,7 +26,7 @@ namespace PCL2.Neo.Models.Minecraft.Java
         {
             var javaEntities = new List<string>();
 
-            javaEntities.AddRange(SearchRegister()); // search registies
+            javaEntities.AddRange(SearchRegister()); // search registries
             javaEntities.AddRange(SearchEnvironment()); // search path
 
             if (fullSearch) javaEntities.AddRange(await SearchDrives(maxDeep)); // full search mode

--- a/PCL2.Neo/Models/Minecraft/Java/Windows.cs
+++ b/PCL2.Neo/Models/Minecraft/Java/Windows.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace PCL2.Neo.Models.Minecraft.Java
 {
-    public class Windows
+    public static class Windows
     {
         private const int MaxDeep = 7;
 

--- a/PCL2.Neo/Views/MainWindow.axaml
+++ b/PCL2.Neo/Views/MainWindow.axaml
@@ -231,7 +231,7 @@
                                     Name="TestLoading"
                                     Width="150" />
                                 <pc:MyButton Height="50" Margin="10" />
-                                <pc:MyButton Height="50" Margin="10" />
+                                <pc:MyButton Height="50" Margin="10" Text="搜索 Java" Click="Search_Java_Button"/>
                                 <pc:MyCard Margin="10" />
                             </StackPanel>
                         </ScrollViewer>

--- a/PCL2.Neo/Views/MainWindow.axaml.cs
+++ b/PCL2.Neo/Views/MainWindow.axaml.cs
@@ -7,7 +7,9 @@ using PCL2.Neo.Animations;
 using PCL2.Neo.Animations.Easings;
 using PCL2.Neo.Controls;
 using PCL2.Neo.Helpers;
+using PCL2.Neo.Models.Minecraft.Java;
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace PCL2.Neo.Views;
@@ -76,5 +78,28 @@ public partial class MainWindow : Window
     private void Button2_OnClick(object? sender, RoutedEventArgs e)
     {
         this.TestLoading.State = MyLoading.LoadingState.Error;
+    }
+
+    private async void Search_Java_Button(object? sender, RoutedEventArgs e)
+    {
+        try
+        {
+            var javas = await Java.SearchJava();
+            Console.WriteLine($"找到 {javas.Count()} 个Java环境:");
+
+            foreach (var java in javas)
+            {
+                Console.WriteLine("----------------------");
+                Console.WriteLine($"路径: {java.Path}");
+                Console.WriteLine($"版本: Java {java.Version}");
+                Console.WriteLine($"位数: {(java.Is64Bit ? "64位" : "32位")}");
+                Console.WriteLine($"类型: {(java.IsJre ? "JRE" : "JDK")}");
+                Console.WriteLine($"可用: {java.IsUsable}");
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"搜索失败: {ex.Message}");
+        }
     }
 }


### PR DESCRIPTION
在Unix.cs中，将SearchJavaExecutables返回的路径改为包含java的目录以匹配Windows的行为；修改文件位置以匹配命名空间；更改版本号正则表达式匹配规则；去除JavaExe中的.exe后缀。

（大学生 对发pr不熟 第一次发了pr以后 我又在那个分支上继续做了不必要的修改 那个就关掉了吧  #62 