### PR TITLE
添加更多系统的架构和兼容性识别

### DIFF
--- a/PCL2.Neo.Tests/Models/Minecraft/JavaTest.cs
+++ b/PCL2.Neo.Tests/Models/Minecraft/JavaTest.cs
@@ -7,10 +7,9 @@ namespace PCL2.Neo.Tests.Models.Minecraft
         [Test]
         public async Task Test()
         {
-            var javaEntities = await Java.SearchJava();
-            IEnumerable<JavaEntity> enumerable = javaEntities.ToList();
-            Console.WriteLine("搜索到 " + enumerable.Count() + " 个 Java");
-            foreach (JavaEntity javaEntity in enumerable)
+            Java javaInstance = await Java.CreateAsync();
+            Console.WriteLine("当前有 " + javaInstance.JavaList.Count + " 个 Java");
+            foreach (JavaEntity? javaEntity in javaInstance.JavaList)
             {
                 Console.WriteLine("--------------------");
                 Console.WriteLine("路径: " + javaEntity.DirectoryPath);

--- a/PCL2.Neo.Tests/Models/Minecraft/JavaTest.cs
+++ b/PCL2.Neo.Tests/Models/Minecraft/JavaTest.cs
@@ -1,4 +1,5 @@
 using PCL2.Neo.Models.Minecraft.Java;
+using PCL2.Neo.Utils;
 
 namespace PCL2.Neo.Tests.Models.Minecraft
 {
@@ -9,12 +10,11 @@ namespace PCL2.Neo.Tests.Models.Minecraft
         {
             Java javaInstance = await Java.CreateAsync();
             Console.WriteLine("当前有 " + javaInstance.JavaList.Count + " 个 Java");
-            foreach (JavaEntity? javaEntity in javaInstance.JavaList)
+            foreach (JavaEntity javaEntity in javaInstance.JavaList)
             {
                 Console.WriteLine("--------------------");
                 Console.WriteLine("路径: " + javaEntity.DirectoryPath);
-                Console.WriteLine("是否兼容: " + javaEntity.Compability);
-                Console.WriteLine("是否通用: " + javaEntity.IsFatFile);
+                Console.WriteLine("架构: " + ArchitectureUtils.GetExecutableArchitecture(javaEntity.JavaExe));
             }
         }
     }

--- a/PCL2.Neo.Tests/Models/Minecraft/PropertiesTest.cs
+++ b/PCL2.Neo.Tests/Models/Minecraft/PropertiesTest.cs
@@ -1,0 +1,14 @@
+using PCL2.Neo.Utils;
+
+namespace PCL2.Neo.Tests.Models.Minecraft
+{
+    public class PropertiesTest
+    {
+        [Test]
+        public void Test()
+        {
+            string version = PropertiesUtils.ReadProperties("/Library/Java/JavaVirtualMachines/zulu-24.jdk/Contents/Home/release")["JAVA_VERSION"];
+            Console.WriteLine(version);
+        }
+    }
+}

--- a/PCL2.Neo/App.axaml.cs
+++ b/PCL2.Neo/App.axaml.cs
@@ -6,14 +6,17 @@ using Avalonia.Data.Core;
 using Avalonia.Data.Core.Plugins;
 using Avalonia.Markup.Xaml;
 using PCL2.Neo.Helpers;
+using PCL2.Neo.Models.Minecraft.Java;
 using PCL2.Neo.Utils;
 using PCL2.Neo.ViewModels;
 using PCL2.Neo.Views;
+using System.Threading.Tasks;
 
 namespace PCL2.Neo
 {
     public partial class App : Application
     {
+        public static Java JavaManager;
         public override void Initialize()
         {
             AvaloniaXamlLoader.Load(this);
@@ -21,6 +24,7 @@ namespace PCL2.Neo
 
         public override void OnFrameworkInitializationCompleted()
         {
+            Task.Run(SetupJavaManager);
             if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
             {
                 // Avoid duplicate validations from both Avalonia and the CommunityToolkit.
@@ -30,6 +34,11 @@ namespace PCL2.Neo
             }
 
             base.OnFrameworkInitializationCompleted();
+        }
+
+        private async Task SetupJavaManager()
+        {
+            JavaManager = await Java.CreateAsync();
         }
 
         private void DisableAvaloniaDataAnnotationValidation()

--- a/PCL2.Neo/Models/Minecraft/Java/Java.cs
+++ b/PCL2.Neo/Models/Minecraft/Java/Java.cs
@@ -1,46 +1,99 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Runtime.InteropServices;
 
-namespace PCL2.Neo.Models.Minecraft.Java
+namespace PCL2.Neo.Models.Minecraft.Java;
+
+/// <summary>
+/// 测试
+/// </summary>
+public class Java
 {
+    public const int JavaListCacheVersion = 0; // [INFO] Java 缓存版本号，大版本更新后应该增加
+    public List<JavaEntity> JavaList { get; private set; } = [];
+
+    private Java() { } // 私有构造函数
+
     /// <summary>
-    /// 测试
+    /// 供外部调用，根据实际情况创建 Java 管理器实例
     /// </summary>
-    public static class Java
+    /// <returns></returns>
+    public static async Task<Java> CreateAsync()
     {
-        public static async Task<IEnumerable<JavaEntity>> SearchJava()
+        var java = new Java();
+        await java.JavaListInit();
+        return java;
+    }
+
+    /// <summary>
+    /// 初始化 Java 列表，但除非没有 Java，否则不进行检查。
+    /// TODO)) 更换为 Logger.cs 中的 logger
+    /// </summary>
+    private async Task JavaListInit()
+    {
+        JavaList = [];
+        try
         {
-            //switch (Environment.OSVersion.Platform)
-            //{
-            //    case PlatformID.Win32NT:
-            //        javaList.AddRange(await JavaSearcher.Windows.SearchJava());
-            //        break;
-            //    case PlatformID.Unix:
-            //        javaList.AddRange(Unix.SerachJavaForLinuxAsync());
-            //        break;
-            //    case PlatformID.MacOSX:
-            //        break;
-            //    default:
-            //        throw new PlatformNotSupportedException();
-            //}
+            // TODO)) 如果本地缓存中已有 Java 列表则读取缓存
+            int readJavaListCacheVersion = 0; // TODO)) 此数字应该从缓存中读取
+            if (readJavaListCacheVersion < JavaListCacheVersion)
+            {
+                // TODO)) 设置本地版本号为 JavaListCacheVersion
+                Console.WriteLine("[Java] 要求 Java 列表缓存更新");
+            }
+            else
+            {
+                // TODO)) 从本地缓存中读取 Java 列表
+            }
 
-            // warning: Environment.OSVersion.Platform will have different performance in different .net planform
-            // detail: .net type :    | system | performance
-            //         .net framewrok:   macos | Not Support
-            //         .net Core <= 3.1  macos | Unix
-            //         .net 5+           macos | macosx
-            // this problenm is fixed by follow code
+            if (JavaList.Count == 0)
+            {
+                Console.WriteLine("[Java] 初始化未找到可用的 Java，将自动触发搜索");
+                JavaList = (await SearchJava()).ToList();
+            }
+            else
+            {
+                Console.WriteLine($"[Java] 缓存中有{JavaList.Count}个可用的 Java：");
+            }
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine("初始化 Java 失败");
+            throw;
+        }
+    }
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                return await Windows.SearchJavaAsync();
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                return await Unix.SearchJavaAsync(OSPlatform.Linux);
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                return await Unix.SearchJavaAsync(OSPlatform.OSX);
+    public async Task ManualAdd(string javaDir)
+    {
+        var entity = await JavaEntity.CreateJavaEntityAsync(javaDir);
+        if (entity is { Compability: not JavaCompability.Error }) JavaList.Add(entity);
+        else Console.WriteLine("添加的 Java 文件无法运行！");
+    }
 
-            throw new PlatformNotSupportedException();
+    public static async Task<IEnumerable<JavaEntity>> SearchJava()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return await Windows.SearchJavaAsync();
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            return await Unix.SearchJavaAsync(OSPlatform.Linux);
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            return await Unix.SearchJavaAsync(OSPlatform.OSX);
+
+        throw new PlatformNotSupportedException();
+    }
+
+    public static async Task TestOutput()
+    {
+        Java javaInstance = await CreateAsync();
+        Console.WriteLine("当前有 " + javaInstance.JavaList.Count + " 个 Java");
+        foreach (JavaEntity? javaEntity in javaInstance.JavaList)
+        {
+            Console.WriteLine("--------------------");
+            Console.WriteLine("路径: " + javaEntity.DirectoryPath);
+            Console.WriteLine("是否兼容: " + javaEntity.Compability);
+            Console.WriteLine("是否通用: " + javaEntity.IsFatFile);
         }
     }
 }

--- a/PCL2.Neo/Models/Minecraft/Java/Java.cs
+++ b/PCL2.Neo/Models/Minecraft/Java/Java.cs
@@ -9,9 +9,11 @@ namespace PCL2.Neo.Models.Minecraft.Java;
 /// <summary>
 /// 测试
 /// </summary>
-public class Java
+public sealed class Java
 {
     public const int JavaListCacheVersion = 0; // [INFO] Java 缓存版本号，大版本更新后应该增加
+    public bool IsInitialized { get; private set; } = false;
+
     public List<JavaEntity> JavaList { get; private set; } = [];
 
     private Java() { } // 私有构造函数
@@ -33,6 +35,7 @@ public class Java
     /// </summary>
     private async Task JavaListInit()
     {
+        if (IsInitialized) return;
         JavaList = [];
         try
         {
@@ -52,24 +55,48 @@ public class Java
             {
                 Console.WriteLine("[Java] 初始化未找到可用的 Java，将自动触发搜索");
                 JavaList = (await SearchJava()).ToList();
+                Console.Write($"[Java] 搜索完成 ");
             }
             else
             {
                 Console.WriteLine($"[Java] 缓存中有{JavaList.Count}个可用的 Java：");
             }
+
+            IsInitialized = true;
+            TestOutput();
         }
         catch (Exception e)
         {
             Console.WriteLine("初始化 Java 失败");
+            IsInitialized = false;
             throw;
         }
     }
 
     public async Task ManualAdd(string javaDir)
     {
-        var entity = await JavaEntity.CreateJavaEntityAsync(javaDir);
+        if (!IsInitialized) return;
+        var entity = await JavaEntity.CreateJavaEntityAsync(javaDir, true);
         if (entity is { Compability: not JavaCompability.Error }) JavaList.Add(entity);
         else Console.WriteLine("添加的 Java 文件无法运行！");
+    }
+
+    public async Task Refresh()
+    {
+        Console.WriteLine("[Java] 正在刷新 Java");
+        List<JavaEntity> newEntities = [];
+        // 对于用户手动导入的 Java，保留并重新检查可用性
+        var oldManualEntities = JavaList.FindAll(entity => entity.IsUserImport);
+        JavaList.Clear();
+        var searchedEntities = (await SearchJava()).ToList();
+        newEntities.AddRange(searchedEntities);
+        foreach (JavaEntity entity in oldManualEntities)
+            if (searchedEntities.All(javaEntity => javaEntity.DirectoryPath != entity.DirectoryPath))
+                if(await entity.RefreshInfo())
+                    newEntities.Add(entity);
+        JavaList = newEntities;
+        Console.WriteLine("[Java] 刷新 Java 完成");
+        TestOutput();
     }
 
     public static async Task<IEnumerable<JavaEntity>> SearchJava()
@@ -84,11 +111,11 @@ public class Java
         throw new PlatformNotSupportedException();
     }
 
-    public static async Task TestOutput()
+    public void TestOutput()
     {
-        Java javaInstance = await CreateAsync();
-        Console.WriteLine("当前有 " + javaInstance.JavaList.Count + " 个 Java");
-        foreach (JavaEntity? javaEntity in javaInstance.JavaList)
+        if (!IsInitialized) return;
+        Console.WriteLine("当前有 " + JavaList.Count + " 个 Java");
+        foreach (JavaEntity? javaEntity in JavaList)
         {
             Console.WriteLine("--------------------");
             Console.WriteLine("路径: " + javaEntity.DirectoryPath);

--- a/PCL2.Neo/Models/Minecraft/Java/JavaData.cs
+++ b/PCL2.Neo/Models/Minecraft/Java/JavaData.cs
@@ -142,7 +142,7 @@ public class JavaEntity
             };
             fileProcess.Start();
             fileProcess.WaitForExit();
-            var arch = fileProcess.StandardOutput.ReadToEnd().Trim().Replace(JavaExe, "").Split(",")[2];
+            var arch = fileProcess.StandardOutput.ReadToEnd().Trim().Replace(JavaExe, "").Split(",")[1];
             info.IsFatFile = false; // TODO 需要进一步判断
             switch (RuntimeInformation.OSArchitecture)
             {

--- a/PCL2.Neo/Models/Minecraft/Java/JavaData.cs
+++ b/PCL2.Neo/Models/Minecraft/Java/JavaData.cs
@@ -4,14 +4,17 @@ using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 
 namespace PCL2.Neo.Models.Minecraft.Java;
+
 public enum JavaCompability
 {
     Unknown,
     Yes,
     No,
     UnderTranslation,
+    Error,
 }
 
 /// <summary>
@@ -27,68 +30,101 @@ public class JavaEntity
     /// <summary>
     /// 描述具体的 Java 信息，内部信息，不应在外部取用
     /// </summary>
-    private readonly Lazy<JavaInfo> _javaInfo;
+    private readonly JavaInfo _javaInfo;
+
+    private JavaEntity(string directoryPath, JavaInfo javaInfo)
+    {
+        DirectoryPath = directoryPath;
+        _javaInfo = javaInfo;
+    }
 
     /// <summary>
     /// 具体的 Java 信息数据结构
     /// </summary>
     private class JavaInfo
     {
-        public int Version { get; set; }
-        public bool Is64Bit { get; set; }
+        public int Version { get; init; }
+
+        public bool Is64Bit { get; init; }
+
         // public Architecture Architecture { get; set; }
-        public bool IsJre { get; set; }
+        public bool IsJre { get; init; }
         public bool IsFatFile { get; set; }
         public JavaCompability Compability { get; set; }
         public required string JavaExe { get; set; }
-        public required string JavaWExe { get; set; }
+        public required string JavaWExe { get; init; }
     }
 
     /// <summary>
-    /// 单个Java 实体的构造函数
+    /// 单个Java 实体的工厂函数
     /// </summary>
     /// <param name="directoryPath">Java 可执行文件的父目录</param>
-    public JavaEntity(string directoryPath)
+    public static async Task<JavaEntity?> CreateJavaEntityAsync(string directoryPath)
     {
         Debug.WriteLine($"创建 JavaEntity: {directoryPath}");
-        DirectoryPath = directoryPath;
-        _javaInfo = new Lazy<JavaInfo>(JavaInfoInit);
+        var javaInfo = await JavaInfoInitAsync(directoryPath);
+        if(javaInfo.Compability == JavaCompability.Error) return null;
+        var javaEntity = new JavaEntity(directoryPath, javaInfo);
+        return javaEntity;
     }
 
-    // 向外暴露的信息
     public bool IsUserImport { get; set; }
-    public int Version => _javaInfo.Value.Version;
-    public bool Is64Bit => _javaInfo.Value.Is64Bit;
-    // public Architecture Architecture => _javaInfo.Value.Architecture;
-    public bool IsFatFile => _javaInfo.Value.IsFatFile;
-    public JavaCompability Compability => _javaInfo.Value.Compability;
-    public bool IsJre => _javaInfo.Value.IsJre;
-    public string JavaExe => Path.Combine(DirectoryPath, "java");   // [INFO] 这里必须直接指定，否则初始化会出错
+    public int Version => _javaInfo.Version;
+    public bool Is64Bit => _javaInfo.Is64Bit;
+    public bool IsFatFile => _javaInfo.IsFatFile;
+    public JavaCompability Compability => _javaInfo.Compability;
+    public bool IsJre => _javaInfo.IsJre;
+    public string JavaExe => Path.Combine(DirectoryPath, "java");
 
     /// <summary>
     /// Windows 特有的 javaw.exe
     /// </summary>
-    public string JavaWExe => _javaInfo.Value.JavaWExe;
+    public string JavaWExe => _javaInfo.JavaWExe;
 
 
-    private JavaInfo JavaInfoInit()
+    private static async Task<JavaInfo> JavaInfoInitAsync(string directoryPath)
     {
         Debug.WriteLine("JavaInfoInit...");
-        var runJavaOutput = GetRunJavaOutput(JavaExe);
+        var javaExe = Path.Combine(directoryPath, "java");
+        string runJavaOutput;
+        try
+        {
+            runJavaOutput = await GetRunJavaOutputAsync(javaExe);
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e);
+            return new JavaInfo
+            {
+                Version = 0,
+                Is64Bit = false,
+                IsJre = false,
+                IsFatFile = false,
+                Compability = JavaCompability.Error,
+                JavaExe = javaExe,
+                JavaWExe = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                    ? Path.Combine(directoryPath, "javaw.exe")
+                    : javaExe,
+            };
+        }
+
         var info = new JavaInfo
         {
             Version = MatchVersion(runJavaOutput), // 设置版本（Version）
             Is64Bit = MatchIs64Bit(runJavaOutput), // 设置位数（Is64Bit）
-            IsJre = !File.Exists(Path.Combine(DirectoryPath,
+            IsJre = !File.Exists(Path.Combine(directoryPath,
                 RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "javac.exe" : "javac")),
             // Architecture = RuntimeInformation.OSArchitecture,
             IsFatFile = false,
             Compability = JavaCompability.Unknown,
-            JavaExe = JavaExe,
+            JavaExe = javaExe,
             JavaWExe = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                ? Path.Combine(DirectoryPath, "javaw.exe")
-                : JavaExe,
+                ? Path.Combine(directoryPath, "javaw.exe")
+                : javaExe,
         };
+
+        if (info.Version == 0)
+            info.Compability = JavaCompability.Error;
 
         // 针对 Windows 设置兼容性，是 64 位则兼容
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -103,15 +139,15 @@ public class JavaEntity
             lipoProcess.StartInfo = new ProcessStartInfo
             {
                 FileName = "/usr/bin/lipo",
-                Arguments = "-info " + JavaExe,
+                Arguments = "-info " + javaExe,
                 UseShellExecute = false,
                 CreateNoWindow = true,
                 RedirectStandardError = true,
                 RedirectStandardOutput = true
             };
             lipoProcess.Start();
-            lipoProcess.WaitForExit();
-            var output = lipoProcess.StandardOutput.ReadToEnd().Trim();
+            await lipoProcess.WaitForExitAsync();
+            var output = (await lipoProcess.StandardOutput.ReadToEndAsync()).Trim();
             var sysArchitecture = RuntimeInformation.OSArchitecture;
             info.IsFatFile = !output.StartsWith("Non-fat file");
             output = output.AfterLast(":");
@@ -122,8 +158,8 @@ public class JavaEntity
                     info.Compability = output.Contains("x86_64") ? JavaCompability.Yes : JavaCompability.No;
                     break;
                 case Architecture.Arm64:
-                    if(output.Contains("arm64")) info.Compability = JavaCompability.Yes;
-                    else if(output.Contains("x86_64")) info.Compability = JavaCompability.UnderTranslation;
+                    if (output.Contains("arm64")) info.Compability = JavaCompability.Yes;
+                    else if (output.Contains("x86_64")) info.Compability = JavaCompability.UnderTranslation;
                     break;
                 default:
                     Debug.Fail("本句报错理论上永远不会出现：可运行Avalonia的macOS不可能是其他架构");
@@ -198,7 +234,7 @@ public class JavaEntity
     /// 运行 java -version 并获取输出
     /// </summary>
     /// <returns></returns>
-    private static string GetRunJavaOutput(string javaExe)
+    private static async Task<string> GetRunJavaOutputAsync(string javaExe)
     {
         using var javaProcess = new Process();
         javaProcess.StartInfo = new ProcessStartInfo
@@ -211,10 +247,10 @@ public class JavaEntity
             RedirectStandardOutput = true
         };
         javaProcess.Start();
-        javaProcess.WaitForExit();
+        await javaProcess.WaitForExitAsync();
 
-        var output = javaProcess.StandardError.ReadToEnd();
-        return output != string.Empty ? output : javaProcess.StandardOutput.ReadToEnd(); // 就是tmd stderr
+        var output = await javaProcess.StandardError.ReadToEndAsync();
+        return output != string.Empty ? output : await javaProcess.StandardOutput.ReadToEndAsync(); // 就是tmd stderr
     }
 
     private static int MatchVersion(string runJavaOutput)

--- a/PCL2.Neo/Models/Minecraft/Java/JavaData.cs
+++ b/PCL2.Neo/Models/Minecraft/Java/JavaData.cs
@@ -198,7 +198,7 @@ public class JavaEntity
             //         break;
             // }
 
-            using FileStream fs = new(JavaExe, FileMode.Open, FileAccess.Read);
+            await using FileStream fs = new(javaExe, FileMode.Open, FileAccess.Read);
             using BinaryReader reader = new(fs);
             if (reader.ReadByte() == 0x7F &&
                 reader.ReadByte() == 'E' &&
@@ -220,7 +220,7 @@ public class JavaEntity
                     // TODO 添加更多的架构判断
                     _ => throw new NotSupportedException($"Unsupported architecture: 0x{eMachine:X4}")
                 };
-                Console.WriteLine($"{JavaExe}: {architecture}"); // for debug
+                Console.WriteLine($"{javaExe}: {architecture}"); // for debug
 
                 info.Compability = architecture == RuntimeInformation.OSArchitecture ? JavaCompability.Yes : JavaCompability.No; // 未判断转译
             }

--- a/PCL2.Neo/Models/Minecraft/Java/JavaData.cs
+++ b/PCL2.Neo/Models/Minecraft/Java/JavaData.cs
@@ -134,33 +134,62 @@ public class JavaEntity
         // 针对 Linux 设置兼容性
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
-            using var fileProcess = new Process();
-            fileProcess.StartInfo = new ProcessStartInfo
+            // using var fileProcess = new Process();
+            // fileProcess.StartInfo = new ProcessStartInfo
+            // {
+            //     FileName = "/usr/bin/file",
+            //     Arguments = "-L " + JavaExe,
+            //     UseShellExecute = false,
+            //     RedirectStandardOutput = true
+            // };
+            // fileProcess.Start();
+            // fileProcess.WaitForExit();
+            // var arch = fileProcess.StandardOutput.ReadToEnd().Trim().Replace(JavaExe, "").Split(",")[1];
+            // info.IsFatFile = false; // TODO 需要进一步判断
+            // switch (RuntimeInformation.OSArchitecture)
+            // {
+            //     case Architecture.X64:
+            //         info.Compability = arch.Contains("x86-64") ? JavaCompability.Yes : JavaCompability.No;
+            //         break;
+            //     case Architecture.Arm64:
+            //         if (arch.Contains("ARM aarch64"))
+            //             info.Compability = JavaCompability.Yes;
+            //         else if (arch.Contains("x86-64"))
+            //             info.Compability = JavaCompability.UnderTranslation; // QEMU
+            //         break;
+            //     default:
+            //         Debug.WriteLine("未知的 Linux 系统架构");
+            //         break;
+            // }
+
+            using FileStream fs = new(JavaExe, FileMode.Open, FileAccess.Read);
+            using BinaryReader reader = new(fs);
+            if (reader.ReadByte() != 0x7F ||
+                reader.ReadByte() != 'E' ||
+                reader.ReadByte() != 'L' ||
+                reader.ReadByte() != 'F')
             {
-                FileName = "/usr/bin/file",
-                Arguments = "-L " + JavaExe,
-                UseShellExecute = false,
-                RedirectStandardOutput = true
-            };
-            fileProcess.Start();
-            fileProcess.WaitForExit();
-            var arch = fileProcess.StandardOutput.ReadToEnd().Trim().Replace(JavaExe, "").Split(",")[1];
-            info.IsFatFile = false; // TODO 需要进一步判断
-            switch (RuntimeInformation.OSArchitecture)
-            {
-                case Architecture.X64:
-                    info.Compability = arch.Contains("x86-64") ? JavaCompability.Yes : JavaCompability.No;
-                    break;
-                case Architecture.Arm64:
-                    if (arch.Contains("ARM aarch64"))
-                        info.Compability = JavaCompability.Yes;
-                    else if (arch.Contains("x86-64"))
-                        info.Compability = JavaCompability.UnderTranslation; // QEMU
-                    break;
-                default:
-                    Debug.WriteLine("未知的 Linux 系统架构");
-                    break;
+                throw new InvalidDataException("Not an ELF file");
             }
+
+            fs.Seek(12, SeekOrigin.Current);
+
+            ushort eMachine = reader.ReadUInt16();
+
+            Architecture architecture = eMachine switch
+            {
+                0x03 => Architecture.X86,
+                0x3E => Architecture.X64,
+                0x28 => Architecture.Arm,
+                0xB7 => Architecture.Arm64,
+                0xF3 => Architecture.RiscV64,
+                0x102 => Architecture.LoongArch64,
+                // TODO 添加更多的架构判断
+                _ => throw new NotSupportedException($"Unsupported architecture: 0x{eMachine:X4}")
+            };
+            Console.WriteLine($"{JavaExe}: {architecture}"); // for debug
+
+            info.Compability = architecture == RuntimeInformation.OSArchitecture ? JavaCompability.Yes : JavaCompability.No; // 未判断转译
         }
 
         // TODO)) 判断其他系统的可执行文件架构

--- a/PCL2.Neo/Models/Minecraft/Java/JavaData.cs
+++ b/PCL2.Neo/Models/Minecraft/Java/JavaData.cs
@@ -1,7 +1,7 @@
+using PCL2.Neo.Utils;
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 
@@ -111,9 +111,11 @@ public class JavaEntity
             };
             lipoProcess.Start();
             lipoProcess.WaitForExit();
-            var output = lipoProcess.StandardOutput.ReadToEnd().Trim().Split(":").Last();
+            var output = lipoProcess.StandardOutput.ReadToEnd().Trim();
             var sysArchitecture = RuntimeInformation.OSArchitecture;
             info.IsFatFile = !output.StartsWith("Non-fat file");
+            output = output.AfterLast(":");
+            Debug.Assert(sysArchitecture is Architecture.X64 or Architecture.Arm64);
             switch (sysArchitecture)
             {
                 case Architecture.X64:
@@ -124,7 +126,7 @@ public class JavaEntity
                     else if(output.Contains("x86_64")) info.Compability = JavaCompability.UnderTranslation;
                     break;
                 default:
-                    Debug.WriteLine("未知的 macOS 系统架构");  // 理论上程序不可能运行到这里
+                    Debug.Fail("本句报错理论上永远不会出现：可运行Avalonia的macOS不可能是其他架构");
                     break;
             }
         }

--- a/PCL2.Neo/Models/Minecraft/Java/JavaData.cs
+++ b/PCL2.Neo/Models/Minecraft/Java/JavaData.cs
@@ -30,7 +30,7 @@ public class JavaEntity
     /// <summary>
     /// 描述具体的 Java 信息，内部信息，不应在外部取用
     /// </summary>
-    private readonly JavaInfo _javaInfo;
+    private JavaInfo _javaInfo;
 
     private JavaEntity(string directoryPath, JavaInfo javaInfo)
     {
@@ -59,12 +59,13 @@ public class JavaEntity
     /// 单个Java 实体的工厂函数
     /// </summary>
     /// <param name="directoryPath">Java 可执行文件的父目录</param>
-    public static async Task<JavaEntity?> CreateJavaEntityAsync(string directoryPath)
+    /// <param name="isUserImport">是否为用户手动导入</param>
+    public static async Task<JavaEntity?> CreateJavaEntityAsync(string directoryPath, bool isUserImport = false)
     {
         Debug.WriteLine($"创建 JavaEntity: {directoryPath}");
         var javaInfo = await JavaInfoInitAsync(directoryPath);
         if(javaInfo.Compability == JavaCompability.Error) return null;
-        var javaEntity = new JavaEntity(directoryPath, javaInfo);
+        var javaEntity = new JavaEntity(directoryPath, javaInfo) { IsUserImport = isUserImport };
         return javaEntity;
     }
 
@@ -228,6 +229,15 @@ public class JavaEntity
 
         // TODO)) 判断其他系统的可执行文件架构
         return info;
+    }
+
+    /// <summary>
+    /// 刷新 Java 实体的信息
+    /// </summary>
+    public async Task<bool> RefreshInfo()
+    {
+        _javaInfo = await JavaInfoInitAsync(DirectoryPath);
+        return _javaInfo.Compability != JavaCompability.Error;
     }
 
     /// <summary>

--- a/PCL2.Neo/Models/Minecraft/Java/JavaData.cs
+++ b/PCL2.Neo/Models/Minecraft/Java/JavaData.cs
@@ -163,9 +163,7 @@ public class JavaEntity
             {
                 info.Compability = JavaCompability.Yes;
                 info.IsFatFile = true;
-            }
-
-            if (executableArchitecture.ToString() == RuntimeInformation.OSArchitecture.ToString())
+            } else if (executableArchitecture.ToString() == RuntimeInformation.OSArchitecture.ToString())
             {
                 info.Compability = JavaCompability.Yes;
             }

--- a/PCL2.Neo/Models/Minecraft/Java/JavaData.cs
+++ b/PCL2.Neo/Models/Minecraft/Java/JavaData.cs
@@ -163,7 +163,8 @@ public class JavaEntity
             {
                 info.Compability = JavaCompability.Yes;
                 info.IsFatFile = true;
-            } else if (executableArchitecture.ToString() == RuntimeInformation.OSArchitecture.ToString())
+            }
+            else if (executableArchitecture.ToString() == RuntimeInformation.OSArchitecture.ToString())
             {
                 info.Compability = JavaCompability.Yes;
             }

--- a/PCL2.Neo/Models/Minecraft/Java/JavaData.cs
+++ b/PCL2.Neo/Models/Minecraft/Java/JavaData.cs
@@ -136,6 +136,12 @@ public class JavaEntity
         {
             var executableArchitecture = ArchitectureUtils.GetExecutableArchitecture(javaExe);
 
+            if (executableArchitecture == ArchitectureUtils.Architecture.FatFile)
+            {
+                info.Compability = JavaCompability.Yes;
+                info.IsFatFile = true;
+            }
+
             if (executableArchitecture.ToString() == RuntimeInformation.OSArchitecture.ToString())
             {
                 info.Compability = JavaCompability.Yes;

--- a/PCL2.Neo/Models/Minecraft/Java/JavaData.cs
+++ b/PCL2.Neo/Models/Minecraft/Java/JavaData.cs
@@ -129,8 +129,8 @@ public class JavaEntity
             }
         }
 
-        // 针对 Linux 和 FreeBSD 设置兼容性
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD))
+        // 针对 Linux 设置兼容性
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
             using var fileProcess = new Process();
             fileProcess.StartInfo = new ProcessStartInfo
@@ -143,7 +143,7 @@ public class JavaEntity
             fileProcess.Start();
             fileProcess.WaitForExit();
             var arch = fileProcess.StandardOutput.ReadToEnd().Trim().Replace(JavaExe, "").Split(",")[2];
-            info.IsFatFile = false;
+            info.IsFatFile = false; // TODO 需要进一步判断
             switch (RuntimeInformation.OSArchitecture)
             {
                 case Architecture.X64:

--- a/PCL2.Neo/Models/Minecraft/Java/JavaData.cs
+++ b/PCL2.Neo/Models/Minecraft/Java/JavaData.cs
@@ -210,7 +210,7 @@ public class JavaEntity
 
                 ushort eMachine = reader.ReadUInt16();
 
-                Architecture architecture = eMachine switch
+                Architecture? architecture = eMachine switch
                 {
                     0x03 => Architecture.X86,
                     0x3E => Architecture.X64,
@@ -219,11 +219,13 @@ public class JavaEntity
                     0xF3 => Architecture.RiscV64,
                     0x102 => Architecture.LoongArch64,
                     // TODO 添加更多的架构判断
-                    _ => throw new NotSupportedException($"Unsupported architecture: 0x{eMachine:X4}")
+                    _ => null
                 };
-                Console.WriteLine($"{javaExe}: {architecture}"); // for debug
-
-                info.Compability = architecture == RuntimeInformation.OSArchitecture ? JavaCompability.Yes : JavaCompability.No; // 未判断转译
+                if (architecture != null)
+                {
+                    Console.WriteLine($"{javaExe}: {architecture.Value}"); // for debug
+                    info.Compability = architecture.Value == RuntimeInformation.OSArchitecture ? JavaCompability.Yes : JavaCompability.No; // 未判断转译
+                }
             }
         }
 

--- a/PCL2.Neo/Models/Minecraft/Java/Windows.cs
+++ b/PCL2.Neo/Models/Minecraft/Java/Windows.cs
@@ -36,8 +36,15 @@ namespace PCL2.Neo.Models.Minecraft.Java
                 .Select(async item => await SearchFolderAsync(item, maxDeep: 6))
                 .SelectMany(it => it.Result);
             javaEntities.AddRange(result);
+            var validEntities = new List<JavaEntity?>();
+            foreach (string validPath in javaEntities)
+            {
+                var newEntity = await JavaEntity.CreateJavaEntityAsync(validPath);
+                if (newEntity is { Compability: not JavaCompability.Error })
+                    validEntities.Add(await JavaEntity.CreateJavaEntityAsync(validPath));
+            }
 
-            return javaEntities.Distinct().Select(it => new JavaEntity(it));
+            return validEntities;
         }
 
         private static IEnumerable<string> SearchRegister()

--- a/PCL2.Neo/Utils/ArchitectureUtils.cs
+++ b/PCL2.Neo/Utils/ArchitectureUtils.cs
@@ -1,0 +1,132 @@
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace PCL2.Neo.Utils;
+
+public static class ArchitectureUtils
+{
+    public enum Architecture
+    {
+        X86,
+        X64,
+        Arm64,
+        FatFile,
+        Unknown
+    }
+
+    public static Architecture GetExecutableArchitecture(string path)
+    {
+        if (!File.Exists(path))
+            throw new FileNotFoundException("Executable file not found.", path);
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return ReadPeHeader(path);
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            return ReadElfHeader(path);
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return ReadMachOHeader(path);
+        }
+
+        return Architecture.Unknown;
+    }
+
+    private static Architecture ReadPeHeader(string filePath)
+    {
+        using var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read);
+        using var reader = new BinaryReader(fs);
+
+        // Check MZ header
+        if (reader.ReadUInt16() != 0x5A4D) // "MZ"
+            return Architecture.Unknown;
+
+        fs.Seek(0x3C, SeekOrigin.Begin);
+        uint peHeaderOffset = reader.ReadUInt32();
+
+        fs.Seek(peHeaderOffset, SeekOrigin.Begin);
+        if (reader.ReadUInt32() != 0x00004550) // "PE\0\0"
+            return Architecture.Unknown;
+
+        // Optional Header Magic
+        fs.Seek(peHeaderOffset + 0x16, SeekOrigin.Begin);
+        ushort machine = reader.ReadUInt16();
+
+        return machine switch
+        {
+            0x014C => Architecture.X86,       // IMAGE_FILE_MACHINE_I386
+            0x8664 => Architecture.X64,       // IMAGE_FILE_MACHINE_AMD64
+            0xAA64 => Architecture.Arm64,     // IMAGE_FILE_MACHINE_ARM64
+            _ => Architecture.Unknown
+        };
+    }
+
+    private static Architecture ReadElfHeader(string filePath)
+    {
+        using var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read);
+        using var reader = new BinaryReader(fs);
+
+        byte[] elfMagic = reader.ReadBytes(4);
+        if (elfMagic[0] != 0x7F || elfMagic[1] != 'E' || elfMagic[2] != 'L' || elfMagic[3] != 'F')
+            return Architecture.Unknown;
+
+        fs.Seek(4, SeekOrigin.Begin); // Skip EI_MAG
+        byte eiClass = reader.ReadByte(); // 1=32-bit, 2=64-bit
+
+        // Skip data encoding (ei_data), version (ei_version), etc.
+        fs.Seek(0x12, SeekOrigin.Begin); // e_machine offset for ELF32/ELF64
+        ushort machine = reader.ReadUInt16();
+
+        return machine switch
+        {
+            0x0003 => Architecture.X86,         // EM_386
+            0x003E => Architecture.X64,         // EM_X86_64
+            0x00B7 => Architecture.Arm64,       // EM_AARCH64
+            _ => Architecture.Unknown
+        };
+    }
+
+    private static Architecture ReadMachOHeader(string filePath)
+    {
+        using var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read);
+        using var reader = new BinaryReader(fs);
+
+        uint magic = reader.ReadUInt32();
+
+        // 判断是否为 Fat File
+        if (magic == 0xBEBAFECA) // FAT_MAGIC or FAT_MAGIC_64
+        {
+            return Architecture.FatFile;
+        }
+
+        bool is64Bit = false;
+        switch (magic)
+        {
+            case 0xFEEDFACE: // MH_MAGIC
+            case 0xCEFAEDFE: // MH_CIGAM (reverse)
+                break;
+            case 0xFEEDFACF: // MH_MAGIC_64
+            case 0xCFFAEDFE: // MH_CIGAM_64 (reverse)
+                is64Bit = true;
+                break;
+            default:
+                return Architecture.Unknown;
+        }
+
+        fs.Seek(is64Bit ? 4 : 0, SeekOrigin.Begin); // Skip magic
+        uint cputype = reader.ReadUInt32();
+
+        return cputype switch
+        {
+            0x7 => Architecture.X86,          // CPU_TYPE_I386
+            0x1000007 => Architecture.X64,    // CPU_TYPE_X86_64
+            0x100000C => Architecture.Arm64,  // CPU_TYPE_ARM64
+            _ => Architecture.Unknown
+        };
+    }
+}

--- a/PCL2.Neo/Utils/PropertiesUtils.cs
+++ b/PCL2.Neo/Utils/PropertiesUtils.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.IO;
+
+namespace PCL2.Neo.Utils;
+
+public static class PropertiesUtils
+{
+    // TODO 添加缓存
+    public static Dictionary<string, string> ReadProperties(string filePath)
+    {
+        var result = new Dictionary<string, string>();
+
+        if (!File.Exists(filePath))
+            throw new FileNotFoundException("文件不存在", filePath);
+
+        foreach (var line in File.ReadAllLines(filePath))
+        {
+            var trimmedLine = line.Trim();
+            if (trimmedLine.StartsWith("#") || string.IsNullOrEmpty(trimmedLine))
+                continue;
+
+            var parts = trimmedLine.Split(new[] { '=' }, 2);
+            if (parts.Length == 2)
+            {
+                var key = parts[0].Trim();
+                var value = parts[1].Trim();
+
+                if (value.Length >= 2 && value.StartsWith("\"") && value.EndsWith("\""))
+                {
+                    value = value.Substring(1, value.Length - 2);
+                }
+
+                result[key] = value;
+            }
+        }
+
+        return result;
+    }
+}

--- a/PCL2.Neo/Views/MainWindow.axaml.cs
+++ b/PCL2.Neo/Views/MainWindow.axaml.cs
@@ -80,34 +80,8 @@ public partial class MainWindow : Window
         this.TestLoading.State = MyLoading.LoadingState.Error;
     }
 
-    private async void Search_Java_Button(object? sender, RoutedEventArgs e)
+    private void Search_Java_Button(object? sender, RoutedEventArgs e)
     {
-        try
-        {
-            var javas = (await Java.SearchJava()).ToList();
-            Console.WriteLine($"找到 {javas.Count} 个Java环境:");
-
-            foreach (var java in javas)
-            {
-                try
-                {
-                    Console.WriteLine("----------------------");
-                    Console.WriteLine($"路径: {java.DirectoryPath}");
-                    var version = java.Version;
-                    Console.WriteLine($"版本: Java {version}");
-                    Console.WriteLine($"位数: {(java.Is64Bit ? "64位" : "32位")}");
-                    Console.WriteLine($"类型: {(java.IsJre ? "JRE" : "JDK")}");
-                    Console.WriteLine($"可用: {java.Compability}");
-                }
-                catch (Exception ex)
-                {
-                    Console.WriteLine($"处理Java信息时出错: {ex.Message}");
-                }
-            }
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"搜索失败: {ex.Message}");
-        }
+        Task.Run(Java.TestOutput);
     }
 }

--- a/PCL2.Neo/Views/MainWindow.axaml.cs
+++ b/PCL2.Neo/Views/MainWindow.axaml.cs
@@ -82,6 +82,6 @@ public partial class MainWindow : Window
 
     private void Search_Java_Button(object? sender, RoutedEventArgs e)
     {
-        Task.Run(Java.TestOutput);
+        Task.Run(App.JavaManager.Refresh);
     }
 }

--- a/PCL2.Neo/Views/MainWindow.axaml.cs
+++ b/PCL2.Neo/Views/MainWindow.axaml.cs
@@ -84,8 +84,8 @@ public partial class MainWindow : Window
     {
         try
         {
-            var javas = await Java.SearchJava();
-            Console.WriteLine($"找到 {javas.Count()} 个Java环境:");
+            var javas = (await Java.SearchJava()).ToList();
+            Console.WriteLine($"找到 {javas.Count} 个Java环境:");
 
             foreach (var java in javas)
             {


### PR DESCRIPTION
通过 `file -L ...` 判断文件架构。
`-L` 参数会递归解析符号链接，输出格式:

`/usr/bin/java: ELF 64-bit LSB pie executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, BuildID[sha1]=2d06c32477208907961eec451ac46d1871803913, for GNU/Linux 3.7.0, stripped`

**命令仅在 Ubuntu 上经过测试。**

自提交 [06a7930](https://github.com/PCL-Community/PCL2.Neo/pull/71/commits/06a79307544bcf10f85588fc9dfcf0c7e6c07390) 起，Linux 架构通过**读取 ELF 文件头**判断。
自提交 [874c314](https://github.com/PCL-Community/PCL2.Neo/pull/71/commits/874c314efd244bf782c6500a858e97e20d41209a) 起，Windows 架构通过**读取 PE 文件头**判断，macOS 架构通过**读取 mach-O 文件头**判断。